### PR TITLE
gocd-base: gocd.{io => org}

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A sample [Moodle](https://moodle.org/) and [SimpleSAMLphp](https://simplesamlphp
 
 * [Ubuntu 16.04.2 LTS](https://www.ubuntu.com/)
 * Configuration management with [Salt](https://saltstack.com/)
-* Continuous delivery with [GoCD](https://www.gocd.io/)
+* Continuous delivery with [GoCD](https://www.gocd.org/)
 * Static file serving with [nginx](http://nginx.org/)
 * [PHP 7.0](http://php.net/), with the FPM SAPI and OPcache
 * [PostgreSQL 9.5](http://www.postgresql.org/)

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -22,7 +22,7 @@ The technical specifications of the environment are as follows:
 
 * [Ubuntu 16.04.2 LTS](https://www.ubuntu.com/)
 * Configuration management with [Salt](https://saltstack.com/)
-* Continuous delivery with [GoCD](https://www.gocd.io/)
+* Continuous delivery with [GoCD](https://www.gocd.org/)
 * Static file serving with [nginx](http://nginx.org/)
 * [PHP](http://php.net/), with the FPM SAPI and OPcache
 * [PostgreSQL 9.5](http://www.postgresql.org/)

--- a/gocd-base/init.sls
+++ b/gocd-base/init.sls
@@ -12,7 +12,7 @@ gocd.key:
 
 gocd.repo:
   pkgrepo.managed:
-    - name: deb https://download.gocd.io /
+    - name: deb https://download.gocd.org /
     - file: /etc/apt/sources.list.d/gocd.list
     - require:
       - cmd: gocd.key


### PR DESCRIPTION
Fixes APT update issues caused by the repository moving and an apparent
issue following the redirect.